### PR TITLE
Github and twitter links for authors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,7 +236,7 @@ GEM
       ethon (>= 0.9.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    unicode-display_width (1.4.0)
+    unicode-display_width (1.4.1)
 
 PLATFORMS
   ruby

--- a/_authors/andrew-lawson.md
+++ b/_authors/andrew-lawson.md
@@ -1,7 +1,6 @@
 ---
 slug: andrew-lawson
 name: Andrew Lawson
-email:
 image:
 twitter:
 ---

--- a/_authors/andrew-lawson.md
+++ b/_authors/andrew-lawson.md
@@ -3,5 +3,6 @@ slug: andrew-lawson
 name: Andrew Lawson
 image:
 twitter:
+github:
 ---
 

--- a/_authors/andy-worsley.md
+++ b/_authors/andy-worsley.md
@@ -3,6 +3,7 @@ slug: andy-worsley
 name: Andy Worsley
 image: 
 twitter: 
+github:
 ---
 
 Andy is Head of Operational Technology at graze.

--- a/_authors/andy-worsley.md
+++ b/_authors/andy-worsley.md
@@ -1,7 +1,6 @@
 ---
 slug: andy-worsley
 name: Andy Worsley
-email: andy.worsley@graze.com
 image: 
 twitter: 
 ---

--- a/_authors/andy-worsley.md
+++ b/_authors/andy-worsley.md
@@ -3,7 +3,7 @@ slug: andy-worsley
 name: Andy Worsley
 image: 
 twitter: 
-github:
+github: andyworsley
 ---
 
 Andy is Head of Operational Technology at graze.

--- a/_authors/burhan-ali.md
+++ b/_authors/burhan-ali.md
@@ -1,7 +1,6 @@
 ---
 slug: burhan-ali
 name: Burhan Ali
-email: burhan.ali@graze.com
 image: https://www.gravatar.com/avatar/6c8c3f4fd2b12c1583919c14633e9657?s=250&d=mm&r=x
 twitter: "@biggianteye"
 ---

--- a/_authors/burhan-ali.md
+++ b/_authors/burhan-ali.md
@@ -3,6 +3,7 @@ slug: burhan-ali
 name: Burhan Ali
 image: https://www.gravatar.com/avatar/6c8c3f4fd2b12c1583919c14633e9657?s=250&d=mm&r=x
 twitter: biggianteye
+github: biggianteye
 ---
 
 Burhan is a Software Developer at graze working on back end services. You can follow him on <a href="https://twitter.com/biggianteye">twitter</a>.

--- a/_authors/burhan-ali.md
+++ b/_authors/burhan-ali.md
@@ -2,7 +2,7 @@
 slug: burhan-ali
 name: Burhan Ali
 image: https://www.gravatar.com/avatar/6c8c3f4fd2b12c1583919c14633e9657?s=250&d=mm&r=x
-twitter: "@biggianteye"
+twitter: biggianteye
 ---
 
 Burhan is a Software Developer at graze working on back end services. You can follow him on <a href="https://twitter.com/biggianteye">twitter</a>.

--- a/_authors/chris-bratt.md
+++ b/_authors/chris-bratt.md
@@ -3,7 +3,7 @@ slug: chris-bratt
 name: Chris Bratt
 image: https://www.gravatar.com/avatar/a13a73b4ddfaa1e54128e6b91ef5b386?s=250&d=mm&r=x
 twitter: 
-github:
+github: chrisbratt
 ---
 
 

--- a/_authors/chris-bratt.md
+++ b/_authors/chris-bratt.md
@@ -1,7 +1,6 @@
 ---
 slug: chris-bratt
 name: Chris Bratt
-email: chris.bratt@graze.com
 image: https://www.gravatar.com/avatar/a13a73b4ddfaa1e54128e6b91ef5b386?s=250&d=mm&r=x
 twitter: 
 ---

--- a/_authors/chris-bratt.md
+++ b/_authors/chris-bratt.md
@@ -3,6 +3,7 @@ slug: chris-bratt
 name: Chris Bratt
 image: https://www.gravatar.com/avatar/a13a73b4ddfaa1e54128e6b91ef5b386?s=250&d=mm&r=x
 twitter: 
+github:
 ---
 
 

--- a/_authors/csaba-pacsko.md
+++ b/_authors/csaba-pacsko.md
@@ -1,7 +1,6 @@
 ---
 slug: csaba-pacsko
 name: Csaba Pacsko
-email:
 image:
 twitter:
 ---

--- a/_authors/csaba-pacsko.md
+++ b/_authors/csaba-pacsko.md
@@ -3,5 +3,6 @@ slug: csaba-pacsko
 name: Csaba Pacsko
 image:
 twitter:
+github:
 ---
 

--- a/_authors/euan-mackie.md
+++ b/_authors/euan-mackie.md
@@ -3,5 +3,6 @@ slug: euan-mackie
 name: Euan Mackie
 image:
 twitter:
+github:
 ---
 

--- a/_authors/euan-mackie.md
+++ b/_authors/euan-mackie.md
@@ -1,7 +1,6 @@
 ---
 slug: euan-mackie
 name: Euan Mackie
-email:
 image:
 twitter:
 ---

--- a/_authors/graze-tech.md
+++ b/_authors/graze-tech.md
@@ -1,7 +1,6 @@
 ---
 slug: graze-tech
 name: graze tech
-email: developers@graze.com
 image: /content/images/2014/Apr/g.jpg
 twitter: 
 ---

--- a/_authors/graze-tech.md
+++ b/_authors/graze-tech.md
@@ -3,6 +3,7 @@ slug: graze-tech
 name: graze tech
 image: /content/images/2014/Apr/g.jpg
 twitter: snack_overflow
+github: graze
 ---
 
 Find us on <a href="https://github.com/graze">GitHub</a> or follow us on <a href="https://twitter.com/snack_overflow">Twitter</a>.

--- a/_authors/graze-tech.md
+++ b/_authors/graze-tech.md
@@ -2,7 +2,7 @@
 slug: graze-tech
 name: graze tech
 image: /content/images/2014/Apr/g.jpg
-twitter: 
+twitter: snack_overflow
 ---
 
 Find us on <a href="https://github.com/graze">GitHub</a> or follow us on <a href="https://twitter.com/snack_overflow">Twitter</a>.

--- a/_authors/hannah-manku.md
+++ b/_authors/hannah-manku.md
@@ -3,5 +3,6 @@ slug: hannah-manku
 name: Hannah Manku
 image:
 twitter:
+github:
 ---
 

--- a/_authors/hannah-manku.md
+++ b/_authors/hannah-manku.md
@@ -1,7 +1,6 @@
 ---
 slug: hannah-manku
 name: Hannah Manku
-email:
 image:
 twitter:
 ---

--- a/_authors/james-weaver.md
+++ b/_authors/james-weaver.md
@@ -3,7 +3,7 @@ slug: james-weaver
 name: James Weaver
 image: /content/images/2017/06/img_9931_720-1-1.jpg
 twitter: 
-github:
+github: james-weaver
 ---
 
 James is a tech lead at graze.

--- a/_authors/james-weaver.md
+++ b/_authors/james-weaver.md
@@ -3,6 +3,7 @@ slug: james-weaver
 name: James Weaver
 image: /content/images/2017/06/img_9931_720-1-1.jpg
 twitter: 
+github:
 ---
 
 James is a tech lead at graze.

--- a/_authors/james-weaver.md
+++ b/_authors/james-weaver.md
@@ -1,7 +1,6 @@
 ---
 slug: james-weaver
 name: James Weaver
-email: james.weaver@graze.com
 image: /content/images/2017/06/img_9931_720-1-1.jpg
 twitter: 
 ---

--- a/_authors/john-smith.md
+++ b/_authors/john-smith.md
@@ -3,6 +3,7 @@ slug: john-smith
 name: John Smith
 image: https://www.gravatar.com/avatar/898dbdb735b0dcb15a28c1525bc7e1b2?s=250&d=mm&r=x
 twitter: 
+github:
 ---
 
 

--- a/_authors/john-smith.md
+++ b/_authors/john-smith.md
@@ -3,7 +3,7 @@ slug: john-smith
 name: John Smith
 image: https://www.gravatar.com/avatar/898dbdb735b0dcb15a28c1525bc7e1b2?s=250&d=mm&r=x
 twitter: 
-github:
+github: john-n-smith
 ---
 
 

--- a/_authors/john-smith.md
+++ b/_authors/john-smith.md
@@ -1,7 +1,6 @@
 ---
 slug: john-smith
 name: John Smith
-email: john@graze.com
 image: https://www.gravatar.com/avatar/898dbdb735b0dcb15a28c1525bc7e1b2?s=250&d=mm&r=x
 twitter: 
 ---

--- a/_authors/lee-jordan.md
+++ b/_authors/lee-jordan.md
@@ -3,5 +3,6 @@ slug: lee-jordan
 name: Lee Jordan
 image:
 twitter:
+github:
 ---
 

--- a/_authors/lee-jordan.md
+++ b/_authors/lee-jordan.md
@@ -1,7 +1,6 @@
 ---
 slug: lee-jordan
 name: Lee Jordan
-email:
 image:
 twitter:
 ---

--- a/_authors/lee-jordan.md
+++ b/_authors/lee-jordan.md
@@ -3,6 +3,6 @@ slug: lee-jordan
 name: Lee Jordan
 image:
 twitter:
-github:
+github: leejordan
 ---
 

--- a/_authors/mark-egan-fuller.md
+++ b/_authors/mark-egan-fuller.md
@@ -1,7 +1,6 @@
 ---
 slug: mark-egan-fuller
 name: Mark Egan-Fuller
-email:
 image:
 twitter:
 ---

--- a/_authors/mark-egan-fuller.md
+++ b/_authors/mark-egan-fuller.md
@@ -3,5 +3,6 @@ slug: mark-egan-fuller
 name: Mark Egan-Fuller
 image:
 twitter:
+github:
 ---
 

--- a/_authors/patrick-troughton.md
+++ b/_authors/patrick-troughton.md
@@ -3,6 +3,6 @@ slug: patrick-troughton
 name: Patrick Troughton
 image:
 twitter:
-github:
+github: patrick-t
 ---
 

--- a/_authors/patrick-troughton.md
+++ b/_authors/patrick-troughton.md
@@ -1,7 +1,6 @@
 ---
 slug: patrick-troughton
 name: Patrick Troughton
-email:
 image:
 twitter:
 ---

--- a/_authors/patrick-troughton.md
+++ b/_authors/patrick-troughton.md
@@ -3,5 +3,6 @@ slug: patrick-troughton
 name: Patrick Troughton
 image:
 twitter:
+github:
 ---
 

--- a/_authors/razel-villanueva.md
+++ b/_authors/razel-villanueva.md
@@ -1,7 +1,6 @@
 ---
 slug: razel-villanueva
 name: Razel Villanueva
-email:
 image:
 twitter:
 ---

--- a/_authors/razel-villanueva.md
+++ b/_authors/razel-villanueva.md
@@ -3,5 +3,6 @@ slug: razel-villanueva
 name: Razel Villanueva
 image:
 twitter:
+github:
 ---
 

--- a/_authors/rokas-petraitis.md
+++ b/_authors/rokas-petraitis.md
@@ -3,7 +3,7 @@ slug: rokas-petraitis
 name: Rokas Petraitis
 image: 
 twitter: 
-github:
+github: RokasDevelopment
 ---
 
 

--- a/_authors/rokas-petraitis.md
+++ b/_authors/rokas-petraitis.md
@@ -3,6 +3,7 @@ slug: rokas-petraitis
 name: Rokas Petraitis
 image: 
 twitter: 
+github:
 ---
 
 

--- a/_authors/rokas-petraitis.md
+++ b/_authors/rokas-petraitis.md
@@ -1,7 +1,6 @@
 ---
 slug: rokas-petraitis
 name: Rokas Petraitis
-email: rokas.petraitis@graze.com
 image: 
 twitter: 
 ---

--- a/_authors/sam-parkinson.md
+++ b/_authors/sam-parkinson.md
@@ -1,7 +1,6 @@
 ---
 slug: sam-parkinson
 name: Sam Parkinson
-email: sam@graze.com
 image: /content/images/2014/11/g.jpg
 twitter: 
 ---

--- a/_authors/sam-parkinson.md
+++ b/_authors/sam-parkinson.md
@@ -1,7 +1,7 @@
 ---
 slug: sam-parkinson
 name: Sam Parkinson
-image: /content/images/2014/11/g.jpg
+image:
 twitter: 
 github: sjparkinson
 ---

--- a/_authors/sam-parkinson.md
+++ b/_authors/sam-parkinson.md
@@ -3,7 +3,7 @@ slug: sam-parkinson
 name: Sam Parkinson
 image: /content/images/2014/11/g.jpg
 twitter: 
-github:
+github: sjparkinson
 ---
 
 

--- a/_authors/sam-parkinson.md
+++ b/_authors/sam-parkinson.md
@@ -3,6 +3,7 @@ slug: sam-parkinson
 name: Sam Parkinson
 image: /content/images/2014/11/g.jpg
 twitter: 
+github:
 ---
 
 

--- a/_authors/simon-plenderleith.md
+++ b/_authors/simon-plenderleith.md
@@ -3,6 +3,7 @@ slug: simon-plenderleith
 name: Simon Plenderleith
 image: 
 twitter: 
+github:
 ---
 
 

--- a/_authors/simon-plenderleith.md
+++ b/_authors/simon-plenderleith.md
@@ -3,7 +3,7 @@ slug: simon-plenderleith
 name: Simon Plenderleith
 image: 
 twitter: 
-github:
+github: simonplend
 ---
 
 

--- a/_authors/simon-plenderleith.md
+++ b/_authors/simon-plenderleith.md
@@ -1,7 +1,6 @@
 ---
 slug: simon-plenderleith
 name: Simon Plenderleith
-email: simon.plenderleith@graze.com
 image: 
 twitter: 
 ---

--- a/_authors/tom-percival.md
+++ b/_authors/tom-percival.md
@@ -1,7 +1,6 @@
 ---
 slug: tom-percival
 name: Tom Percival
-email:
 image:
 twitter:
 ---

--- a/_authors/tom-percival.md
+++ b/_authors/tom-percival.md
@@ -3,5 +3,6 @@ slug: tom-percival
 name: Tom Percival
 image:
 twitter:
+github:
 ---
 

--- a/_authors/will-pillar.md
+++ b/_authors/will-pillar.md
@@ -1,7 +1,6 @@
 ---
 slug: will-pillar
 name: Will Pillar
-email: will.pillar@graze.com
 image: https://www.gravatar.com/avatar/d3da9bb9f70e05018371ad00d7804924?s=250&d=mm&r=x
 twitter: 
 ---

--- a/_authors/will-pillar.md
+++ b/_authors/will-pillar.md
@@ -2,7 +2,7 @@
 slug: will-pillar
 name: Will Pillar
 image: https://www.gravatar.com/avatar/d3da9bb9f70e05018371ad00d7804924?s=250&d=mm&r=x
-twitter: 
+twitter: willpillar
 ---
 
 Will is a Lead PHP Developer at graze. You can follow him on <a href="https://twitter.com/willpillar">Twitter</a>

--- a/_authors/will-pillar.md
+++ b/_authors/will-pillar.md
@@ -3,6 +3,7 @@ slug: will-pillar
 name: Will Pillar
 image: https://www.gravatar.com/avatar/d3da9bb9f70e05018371ad00d7804924?s=250&d=mm&r=x
 twitter: willpillar
+github:
 ---
 
 Will is a Lead PHP Developer at graze. You can follow him on <a href="https://twitter.com/willpillar">Twitter</a>

--- a/_authors/will-pillar.md
+++ b/_authors/will-pillar.md
@@ -3,7 +3,7 @@ slug: will-pillar
 name: Will Pillar
 image: https://www.gravatar.com/avatar/d3da9bb9f70e05018371ad00d7804924?s=250&d=mm&r=x
 twitter: willpillar
-github:
+github: wpillar
 ---
 
 Will is a Lead PHP Developer at graze. You can follow him on <a href="https://twitter.com/willpillar">Twitter</a>

--- a/_config.yml
+++ b/_config.yml
@@ -19,3 +19,6 @@ defaults:
       layout: "default"
 
 paginate: 10
+
+plugins:
+  - jekyll-avatar

--- a/_layouts/author.html
+++ b/_layouts/author.html
@@ -11,6 +11,8 @@ layout: default
             <h1>{{ page.name }}</h1>
             {% if page.image %}
             <img src="{{ page.image | relative_url }}" alt="Picture of {{ page.name }}"></img>
+            {% else if page.github %}
+            {% avatar user=page.github size=256 %}
             {% endif %}
             {{ content }}
             <p class="buttons">

--- a/_layouts/author.html
+++ b/_layouts/author.html
@@ -3,31 +3,49 @@ layout: default
 ---
 
 <section class="section">
-    <div class="container">
-      <div class="column is-8 is-offset-2">
-        <div class="card">
-          <div class="card-content">
-            <div class="content">
-                <h1>{{ page.name }}</h1>
-                {% if page.image %}
-                <img src="{{ page.image | relative_url }}" alt="Picture of {{ page.name }}"></img>
-                {% endif %}
-                {{ content }}
-            </div>
+  <div class="container">
+    <div class="column is-8 is-offset-2">
+      <div class="card">
+        <div class="card-content">
+          <div class="content">
+            <h1>{{ page.name }}</h1>
+            {% if page.image %}
+            <img src="{{ page.image | relative_url }}" alt="Picture of {{ page.name }}"></img>
+            {% endif %}
+            {{ content }}
+            <p class="buttons">
+              {% if page.github %}
+              <a href="https://github.com/{{ page.github }}" class="button">
+                <span class="icon">
+                  <i class="fab fa-github"></i>
+                </span>
+                <span>GitHub</span>
+              </a>
+              {% endif %}
+              {% if page.twitter %}
+              <a href="https://twitter.com/{{ page.twitter }}" class="button">
+                <span class="icon">
+                  <i class="fab fa-twitter"></i>
+                </span>
+                <span>Twitter</span>
+              </a>
+              {% endif %}
+            </p>
           </div>
+        </div>
 
-          <div class="card-content">
-              <div class="content">
-                  <h2>Posts</h2>
-                  <ul>
-                    {% assign filtered_posts = site.posts | where: 'author', page.slug %}
-                    {% for post in filtered_posts %}
-                      <li><a href="{{ post.url | relative_url }}">{{ post.title }}</a></li>
-                    {% endfor %}
-                  </ul>
-              </div>
+        <div class="card-content">
+          <div class="content">
+            <h2>Posts</h2>
+            <ul>
+              {% assign filtered_posts = site.posts | where: 'author', page.slug %}
+              {% for post in filtered_posts %}
+              <li><a href="{{ post.url | relative_url }}">{{ post.title }}</a></li>
+              {% endfor %}
+            </ul>
           </div>
         </div>
       </div>
     </div>
+  </div>
 </section>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <title>{{ page.title }}</title>
     <link rel="stylesheet" href="{{ "/assets/css/styles.css?v=" | append: site.github.build_revision | relative_url }}">
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.3/css/all.css" integrity="sha384-UHRtZLI+pbxtHCWp1t77Bi1L4ZtiqrqD80Kn4Z8NTSRyMA2Fd33n5dQ8lWUE00s/" crossorigin="anonymous">
   </head>
 
   <body>

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -3,6 +3,7 @@
 @import 'vendor/bulma-0.7.2/sass/base/_all.sass';
 
 // @import 'vendor/bulma-0.7.2/sass/elements/_all.sass';
+@import 'vendor/bulma-0.7.2/sass/elements/button.sass';
 @import 'vendor/bulma-0.7.2/sass/elements/container.sass';
 @import 'vendor/bulma-0.7.2/sass/elements/content.sass';
 @import 'vendor/bulma-0.7.2/sass/elements/tag.sass';


### PR DESCRIPTION
- Github and twitter links on author pages
- Pull in image from github if none explicitly specified.
- Removed the `email` property. No point in having this info.